### PR TITLE
Changing Statement to Function

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -99,7 +99,7 @@ identifier_name:
 nesting:
   type_level:
     warning: 2
-  statement_level:
+  function_level:
     warning: 3
 
 switch_case_alignment:


### PR DESCRIPTION
to silence SwiftLint warning 'statement_level' has been renamed to 'function_level' and will be completely removed in a future release.